### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/infrastructure/template.json
+++ b/infrastructure/template.json
@@ -32,7 +32,7 @@
           "Role": {
             "Fn::GetAtt": ["GHCLambdaRole","Arn"]
           },
-          "Runtime": "python3.7",
+          "Runtime": "python3.10",
           "Handler": "index.lambda_handler",
           "Code": {
             "ZipFile": "def lambda_handler(event, context):\n  message = \"Replace me with GHC code!\"\n  return message\n"


### PR DESCRIPTION
CloudFormation templates in build-your-own-qr-code-web-app-with-aws have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.